### PR TITLE
Nparray-fix

### DIFF
--- a/src/MetaArray/__init__.py
+++ b/src/MetaArray/__init__.py
@@ -117,7 +117,7 @@ class MetaArray(object):
             elif isinstance(data, tuple):  # create empty array with specified shape
                 self._data = np.empty(data, dtype=dtype)
             else:
-                self._data = np.asarray(data, dtype=dtype, copy=copy)
+                self._data = np.asarray(data, dtype=dtype) # , copy=copy)
 
         # run sanity checks on info structure
         self.checkInfo()

--- a/src/MetaArray/__init__.py
+++ b/src/MetaArray/__init__.py
@@ -117,13 +117,14 @@ class MetaArray(object):
             elif isinstance(data, tuple):  # create empty array with specified shape
                 self._data = np.empty(data, dtype=dtype)
             else:
-                self._data = np.array(data, dtype=dtype, copy=copy)
+                self._data = np.asarray(data, dtype=dtype, copy=copy)
 
         # run sanity checks on info structure
         self.checkInfo()
 
     def checkInfo(self):
-        info = self._info
+        print(dir(self._info))
+        info = np.asarray(self._info)
         if info is None:
             if self._data is None:
                 return

--- a/src/MetaArray/__init__.py
+++ b/src/MetaArray/__init__.py
@@ -117,13 +117,12 @@ class MetaArray(object):
             elif isinstance(data, tuple):  # create empty array with specified shape
                 self._data = np.empty(data, dtype=dtype)
             else:
-                self._data = np.asarray(data, dtype=dtype) # , copy=copy)
+                self._data = np.asarray(data, dtype=dtype)
 
         # run sanity checks on info structure
         self.checkInfo()
 
     def checkInfo(self):
-        print(dir(self._info))
         info = np.asarray(self._info)
         if info is None:
             if self._data is None:


### PR DESCRIPTION
I was getting occasional failures on line 120 and 126 when analyzing acq4 data under Python 3.13 and numpy 2.2.6. Using the suggested "np.asarray" instead of "np.array" fixed this. Note that the "copy" flag has been removed so that object is only copied as needed. 

